### PR TITLE
Make python version the same between circleci and readthedocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ workflows:
       - onegini-build/build-docs:
           executor:
             name: onegini-build/docs-builder
-            tag: "3.7-browsers" # Keep in line with readthedocs.yml python version
+            tag: "3.8-browsers" # Keep in line with readthedocs.yml python version otherwise requirements.txt may fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,5 +9,4 @@ workflows:
       - onegini-build/build-docs:
         executor:
           name: onegini-build/docs-builder
-          # Keep in line with readthedocs.yml python version
-          tag: "3.7-browsers"
+          tag: "3.7-browsers" # Keep in line with readthedocs.yml python version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,8 @@ workflows:
   version: 2
   build-workflow:
     jobs:
-      - onegini-build/build-docs
+      - onegini-build/build-docs:
+        executor:
+          name: onegini-build/docs-builder
+          # Keep in line with readthedocs.yml python version
+          tag: "3.7-browsers"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,6 @@ workflows:
   build-workflow:
     jobs:
       - onegini-build/build-docs:
-        executor:
-          name: onegini-build/docs-builder
-          tag: "3.7-browsers" # Keep in line with readthedocs.yml python version
+          executor:
+            name: onegini-build/docs-builder
+            tag: "3.7-browsers" # Keep in line with readthedocs.yml python version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-    onegini-build: onegini/onegini-build@2
+    onegini-build: onegini/onegini-build@3
 
 workflows:
   version: 2

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -2,6 +2,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
+    ## Keep in line with config.yml executor python version
     python: "3.8"
 python:
   install:


### PR DESCRIPTION
This should catch issues with python version and the requirements.txt